### PR TITLE
singlehost: Allow for space character in City parameter.

### DIFF
--- a/examples/single-host/run_all.sh
+++ b/examples/single-host/run_all.sh
@@ -183,7 +183,7 @@ generate_config() {
         --org-name "$ORG_NAME" \
         --country-code $COUNTRY_CODE \
         --state $STATE \
-        --city $CITY \
+        --city "$CITY" \
         --ldap-type opendj
 }
 


### PR DESCRIPTION
Updated run_all.sh to allow for e.g. "Buenos Aires"