### PR TITLE
Minor changes to get run all running

### DIFF
--- a/examples/single-host/consul-config.json
+++ b/examples/single-host/consul-config.json
@@ -1,0 +1,9 @@
+{
+	"client_addr": "0.0.0.0",
+	"ports": {
+		"dns": 53
+	},
+	"ui": true,
+	"server": true,
+    "bootstrap_expect": 1
+}

--- a/examples/single-host/docker-compose.yml
+++ b/examples/single-host/docker-compose.yml
@@ -4,15 +4,12 @@ version: "2.3"
 services:
   consul:
     image: consul
-    command: agent -server -bootstrap -ui
     hostname: consul-1
     environment:
       - CONSUL_BIND_INTERFACE=eth0
       - CONSUL_CLIENT_INTERFACE=eth0
     container_name: consul
     restart: unless-stopped
-    ports:
-      - "8500:8500"
     volumes:
       - ./volumes/consul:/consul/data
       - ./consul-config.json:/consul/etc/config.json

--- a/examples/single-host/docker-compose.yml
+++ b/examples/single-host/docker-compose.yml
@@ -11,8 +11,11 @@ services:
       - CONSUL_CLIENT_INTERFACE=eth0
     container_name: consul
     restart: unless-stopped
+    ports:
+      - "8500:8500"
     volumes:
       - ./volumes/consul:/consul/data
+      - ./consul-config.json:/consul/etc/config.json
     labels:
       - "SERVICE_IGNORE=yes"
     restart: unless-stopped

--- a/examples/single-host/run_all.sh
+++ b/examples/single-host/run_all.sh
@@ -163,7 +163,6 @@ prepare_config_secret() {
     retry=1
     while [[ $retry -le 3 ]]; do
         sleep 5
-        consul_ip=$($DOCKER inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' consul)
         DOMAIN=$($DOCKER exec -it consul curl localhost:8500/v1/kv/gluu/config/hostname?raw -s)
 
         if [[ $DOMAIN != "" ]]; then


### PR DESCRIPTION
This PR contains the following change:

* Added Consul configuration file as it seems that the `entrypoints.sh` script is not accepting any arguments given in the `command`;
* `check_health` failed on Mac because the `date` command does work differently on a Linux system;
* Some `curl` commands did not work with when accessing the ip on a Mac;
* The `if [ $has_gcp` was not working with a single `=` character.

The above mentioned changes where needed on my Mac (10.14, Docker 2.0.1) to get everything running. Please let me know if any changes are needed (or if I do something very stupid 😄 ).